### PR TITLE
Fix ovoplayerctrl not working on *nix

### DIFF
--- a/tools/ovoplayerctrl/ovoplayerctrl.lpr
+++ b/tools/ovoplayerctrl/ovoplayerctrl.lpr
@@ -82,7 +82,7 @@ type
 
   var
   BaseServerId:string = 'SI_';
-  AppNameServerID :string  = 'ovoplayer_exe';
+  AppNameServerID :string  = {$IFDEF WINDOWS}'ovoplayer_exe'{$ELSE}'ovoplayer'{$ENDIF};
   AppVersion : string = {$I ..\..\src\version.inc};
 
 function TOvoPlayerCtrl.PostCommand(Category:string; Command:string;Parameter:string=''): Boolean;
@@ -299,3 +299,4 @@ begin
   Application.Run;
   Application.Free;
 end.
+


### PR DESCRIPTION
This simple patch fixes ovoplayerctrl on linux/unix. The player file will not have exe extension outside of windows, so without this change it is impossible to connect the ctrl to the player.