### PR TITLE
Fix notification window always appearing in preferences

### DIFF
--- a/src/uconfig.pas
+++ b/src/uconfig.pas
@@ -247,6 +247,8 @@ end;
 
 procedure TfConfig.rgOSDKindClick(Sender: TObject);
 begin
+  if not(pcConfig.ActivePage = tsOSD) then Exit;
+
   if rgOSDKind.ItemIndex = 2 then
      begin
    //     if Assigned(fOSD) then


### PR DESCRIPTION
This patch fixes the notification window always appearing when opening preferences. It will now only appear when the notification tab is open. The OnClick handler is fired even when the radio group is changed programatically, which is what triggered the bug.