### PR TITLE
Do not hide the window when the tray icon is disabled

### DIFF
--- a/src/umain.pas
+++ b/src/umain.pas
@@ -1348,7 +1348,7 @@ begin
   end
   else
   begin
-    Application.ShowMainForm := False;
+    Application.ShowMainForm := True;
     TrayIcon.Visible := False;
   end;
 


### PR DESCRIPTION
This fixes a case where the window is not showing at all if the tray icon is disabled in the preferences.