### PR TITLE
Fix unicode in modifying media tag values

### DIFF
--- a/src/ovotag/tag_id3v2.pas
+++ b/src/ovotag/tag_id3v2.pas
@@ -341,6 +341,13 @@ begin
   header.Flags := 0;
   tmpSize := 0;
 
+  // Remove empty frames
+  for i := Count - 1 downto 0 do
+  begin
+    if Frames[i].Size = 0 then
+      Remove(Frames[i]);
+  end;
+
   for i := 0 to Count - 1 do
   begin
     tmpSize := tmpSize + Frames[i].Size + HeadSize;


### PR DESCRIPTION
The problem is that ovoplayer does not handle unicode media tags correctly when modifying them. It removes characters at the end of the tag. If the last character is non-ascii, it may become completely broken.

Since it removed characters exclusively at the end, it led me to believe that length calculation is wrong somewhere. I found this place where UTF8Length is used for mp3 files, yet it is later used to copy individual bytes. I think this is an error, since UTF8Length will return the number of characters, not bytes. It seems to fix the issue.

However, I'm not sure if that UTF16 portion of the procedure will not break (my files only have ID3v2.4). Also, I took a quick look at other formats and I saw no UTF8Length uses, but did not test them.

I think it would be beneficial to have an automated test suite to test all kind of format / version combinations, but that's something to do in the future. 