### PR TITLE
Fix VLC backend on FreeBSD

### DIFF
--- a/src/import-engines/PasLibVlcUnit.pas
+++ b/src/import-engines/PasLibVlcUnit.pas
@@ -5517,7 +5517,7 @@ const
   {$ENDIF}
   
 var
-  libvlc_handle : THandle;
+  libvlc_handle : TLibHandle;
 
 function libvlc_delay(pts : Int64) : Int64;{$IFDEF DELPHI2005_UP}inline;{$ENDIF}
 begin


### PR DESCRIPTION
This small modification enables VLC backend on FreeBSD. Let me know if you think it should be behind a `{$IFDEF}` guard, but functions that load from DLL like `GetProcedureAddress` are documented to work with TLibHandle.